### PR TITLE
AGP 4.2.1 compatibility

### DIFF
--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -2,5 +2,5 @@ project.group 'digital.wup'
 project.version '3.6.4-SNAPSHOT'
 
 ext {
-    build_tools_version = '3.4.1'
+    build_tools_version = '4.2.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.1'
     id 'com.gradle.plugin-publish' version '0.9.10'
-    id 'org.ajoberstar.git-publish' version '0.4.1'
+    id 'org.ajoberstar.git-publish' version '3.0.0'
     id 'idea'
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.8.2'

--- a/plugin/src/main/groovy/digital/wup/android_maven_publish/DefaultPublishConfiguration.groovy
+++ b/plugin/src/main/groovy/digital/wup/android_maven_publish/DefaultPublishConfiguration.groovy
@@ -51,6 +51,8 @@ class DefaultPublishConfiguration implements PublishConfiguration {
             int compare(PublishArtifact a1, PublishArtifact a2) {
                 "${a1.file.path}${a1.type}${a1.classifier}" <=> "${a2.file.path}${a2.type}${a2.classifier}"
             }
-        })
+        }).findAll {artifact ->
+            artifact.extension != null && artifact.classifier != null
+        }
     }
 }


### PR DESCRIPTION
These were the compatibility issues:
* `DefaultPublishConfiguration`: for some reason, in AGP >= 4.2, `Configuration.getAllArtifacts()` returns duplicates where classifier is null. This causes publishing to break as it doesn't allow multiple artifacts with the same (extension, classifier)-tuple for one publication. To fix this, we filter out these null-classifier artifacts from `DefaultPublishConfiguration.getArtifacts()`.

* `VariantPublishConfiguration`: it looks like the archive task that assemble depends on for AGP >= 4.2 is no longer a plain `Task`-object, but rather, a wrapper (of type `org.gradle.api.internal.file.DefaultFilePropertyFactory$DefaultRegularFileVar`) that lazily produces the task when needed. This causes publishing to break as we currently assume that the archiving that assemble depends on is a pure `Zip`-task. To fix this, we account for possibility of the archiving task being of the wrapper type as well.